### PR TITLE
Fix swimlane bug

### DIFF
--- a/R/g_swimlane.R
+++ b/R/g_swimlane.R
@@ -222,7 +222,7 @@ g_swimlane <- function(bar_id,
       aes(x = marker_id, y = marker_pos, shape = marker_shape, color = marker_color),
       size = 2.5, na.rm = TRUE
     )
-    limits_y <- c(0, max(bar_length, marker_pos) + 5)
+    limits_y <- c(0, max(bar_length, marker_pos, na.rm = TRUE) + 5)
 
     if (!is.null(marker_shape)) {
       p <- p + guides(shape = guide_legend("Marker Shape", order = 2))


### PR DESCRIPTION
closes #59 
The error stems from https://github.com/insightsengineering/osprey/blob/4af2ac69d5f4b7ba672e1c683e98d43a208298f8/R/g_swimlane.R#L225 where the 2 values `var_length` and `marker_pos` have `NA`s in the example app. Adding `na.rm = TRUE` to the max function shall solve the issue.
Please test with the example app in the issue above.
