### PR TITLE
fix example

### DIFF
--- a/R/g_patient_profile.R
+++ b/R/g_patient_profile.R
@@ -73,14 +73,14 @@
 #' # ADSL
 #' rADSL <- synthetic_cdisc_data("latest")$adsl
 #' ADSL <- rADSL %>%
-#'   group_by(USUBJID) %>%
+#'   filter(USUBJID == rADSL$USUBJID[1]) %>%
 #'   mutate(
 #'     TRTSDT = as.Date(TRTSDTM),
 #'     max_date = max(as.Date(LSTALVDT), as.Date(DTHDT), na.rm = TRUE),
 #'     max_day = as.numeric(as.Date(max_date) - as.Date(TRTSDT)) + 1
 #'   ) %>%
-#'   select(USUBJID, STUDYID, TRTSDT, max_day) %>%
-#'   filter(USUBJID == rADSL$USUBJID[1])
+#'   select(USUBJID, STUDYID, TRTSDT, max_day)
+#'
 #'
 #'
 #' # Example 1 Exposure "ADEX"
@@ -346,8 +346,8 @@ patient_domain_profile <- function(domain = NULL,
     line_data <- data.frame(
       var_names,
       line_col = if (is.null(line_col)) to_n("x", length(var_names)) else line_col,
-      line_start = unname(marker_pos[, 1]),
-      line_end = unname(marker_pos[, 2]),
+      line_start = unname(dplyr::pull(marker_pos, 1)),
+      line_end = unname(dplyr::pull(marker_pos, 2)),
       line_min = rep(xlim[1], length(var_names)),
       line_max = rep(arrow_end + no_enddate_extention, length(var_names))
     )
@@ -623,14 +623,14 @@ patient_domain_profile <- function(domain = NULL,
 #' # ADSL
 #' rADSL <- synthetic_cdisc_data("latest")$adsl
 #' ADSL <- rADSL %>%
-#'   group_by(USUBJID) %>%
+#'   filter(USUBJID == rADSL$USUBJID[1]) %>%
 #'   mutate(
 #'     TRTSDT = as.Date(TRTSDTM),
 #'     max_date = max(as.Date(LSTALVDT), as.Date(DTHDT), na.rm = TRUE),
 #'     max_day = as.numeric(as.Date(max_date) - as.Date(TRTSDT)) + 1
 #'   ) %>%
-#'   select(USUBJID, STUDYID, TRTSDT, max_day) %>%
-#'   filter(USUBJID == rADSL$USUBJID[1])
+#'   select(USUBJID, STUDYID, TRTSDT, max_day)
+#'
 #'
 #' # ADEX
 #' rADEX <- synthetic_cdisc_data("latest")$adex

--- a/man/g_patient_profile.Rd
+++ b/man/g_patient_profile.Rd
@@ -83,14 +83,14 @@ library(nestcolor)
 # ADSL
 rADSL <- synthetic_cdisc_data("latest")$adsl
 ADSL <- rADSL \%>\%
-  group_by(USUBJID) \%>\%
+  filter(USUBJID == rADSL$USUBJID[1]) \%>\%
   mutate(
     TRTSDT = as.Date(TRTSDTM),
     max_date = max(as.Date(LSTALVDT), as.Date(DTHDT), na.rm = TRUE),
     max_day = as.numeric(as.Date(max_date) - as.Date(TRTSDT)) + 1
   ) \%>\%
-  select(USUBJID, STUDYID, TRTSDT, max_day) \%>\%
-  filter(USUBJID == rADSL$USUBJID[1])
+  select(USUBJID, STUDYID, TRTSDT, max_day)
+
 
 # ADEX
 rADEX <- synthetic_cdisc_data("latest")$adex

--- a/man/patient_domain_profile.Rd
+++ b/man/patient_domain_profile.Rd
@@ -107,14 +107,14 @@ library(dplyr)
 # ADSL
 rADSL <- synthetic_cdisc_data("latest")$adsl
 ADSL <- rADSL \%>\%
-  group_by(USUBJID) \%>\%
+  filter(USUBJID == rADSL$USUBJID[1]) \%>\%
   mutate(
     TRTSDT = as.Date(TRTSDTM),
     max_date = max(as.Date(LSTALVDT), as.Date(DTHDT), na.rm = TRUE),
     max_day = as.numeric(as.Date(max_date) - as.Date(TRTSDT)) + 1
   ) \%>\%
-  select(USUBJID, STUDYID, TRTSDT, max_day) \%>\%
-  filter(USUBJID == rADSL$USUBJID[1])
+  select(USUBJID, STUDYID, TRTSDT, max_day)
+
 
 
 # Example 1 Exposure "ADEX"


### PR DESCRIPTION
Closes #97 

1) Moved the filter to before the max call
2) Used dplyr::pull as that works with tibbles and data.frames
![image](https://user-images.githubusercontent.com/15201933/189307931-ef49306e-23b6-4017-aa26-dc594e63c175.png)
3) Left `guides = FALSE` though it's deprecated as it's only deprecated for ggplot 3.3.4 and I'm not sure what version we have in places - if we're sure it will work then there are 3 places to change FALSE to "none"


FYI @kumamiao 