### PR TITLE
release 0.1.16 [skip vbump] [skip spelling]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: osprey
 Title: R Package to Create TLGs
-Version: 0.1.15.9015
-Date: 2023-07-27
+Version: 0.1.16
+Date: 2023-08-11
 Authors@R: c(
     person("Nina", "Qi", , "qit3@gene.com", role = c("aut", "cre")),
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# osprey 0.1.15.9015
+# osprey 0.1.16
 
 * Removed `scda` package dependency from examples.
 * Updated deprecated argument specification in calls to `guides`.
@@ -7,13 +7,13 @@
 
 ### Enhancements
 
-* Implemented `nestcolor` with slight refactoring to `g_events_term_id`, `g_heat_bygrade`, `g_patient_profile`, 
+* Implemented `nestcolor` with slight refactoring to `g_events_term_id`, `g_heat_bygrade`, `g_patient_profile`,
   `g_swimlane`, and `g_waterfall`. Added `nestcolor` in examples without custom color manuals.
 * Updated installation instructions in the `README`.
 
 ### Fixes
 
-* Fixed a failure in `g_patient_profile` example. 
+* Fixed a failure in `g_patient_profile` example.
 
 # osprey 0.1.14
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # osprey 0.1.16
 
+### Miscellaneous
+
 * Removed `scda` package dependency from examples.
 * Updated deprecated argument specification in calls to `guides`.
 


### PR DESCRIPTION
Releasing 0.1.16

Linking with:
https://github.com/insightsengineering/nestdevs-tasks/issues/25